### PR TITLE
Replace CBL-Mariner with Azure Linux

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -14,7 +14,7 @@ jobs:
           centos, centos8, fedora, mageia,
           opensuse, oraclelinux, rockylinux,
           archlinux, manjarolinux,
-          cbl-mariner, chimeralinux,
+          azurelinux, chimeralinux,
           gentoo, solus, void-linux]
           # parrot
           # redhat

--- a/azurelinux/Dockerfile
+++ b/azurelinux/Dockerfile
@@ -1,25 +1,32 @@
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
+FROM mcr.microsoft.com/azurelinux/base/core:3.0
+
 LABEL maintainer "TAKANO Mitsuhiro <takano32@gmail.com>"
 
-RUN yum upgrade -y
-RUN yum clean all
-RUN yum install -y git
+RUN tdnf upgrade -y
+RUN tdnf install -y ca-certificates git
+RUN tdnf clean all
 
 ENV ORIGIN=https://github.com/microsoft/CBL-Mariner-Linux-Kernel.git
+
 RUN git config --global http.sslVerify false
 RUN git clone --depth 1 ${ORIGIN} /build-kernel/linux
 RUN while :; do cd /build-kernel/linux && git fetch --unshallow && break || sleep 5; done
 RUN cd /build-kernel/linux && git pull --all
 
-RUN yum install -y make gcc bc bison flex awk openssl-devel
-RUN yum install -y binutils diffutils cpio zstd rpm-build rsync
-RUN yum install -y llvm clang lld
-RUN yum install -y glibc-headers kernel-headers
+RUN tdnf install -y \
+    make gcc bc bison flex gawk \
+    openssl-devel \
+    binutils diffutils cpio zstd rpm-build rsync \
+    llvm clang lld \
+    glibc-devel kernel-headers \
+    elfutils-libelf-devel dwarves perl \
+    tar gzip xz
 
-RUN yum clean all
+RUN tdnf clean all
 
 COPY ./entrypoint.sh /
 RUN chmod 755 /entrypoint.sh
-EXPOSE 8000
-ENTRYPOINT ["/entrypoint.sh"]
 
+EXPOSE 8000
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,10 +17,10 @@ services:
       dockerfile: ./archlinux/Dockerfile
     ports:
       - 8003:8000
-  cbl-mariner:
+  azurelinux:
     build:
       context: .
-      dockerfile: ./cbl-mariner/Dockerfile
+      dockerfile: ./azurelinux/Dockerfile
     ports:
       - 8019:8000
   centos:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,7 +45,7 @@ unset IFS
 cd /build-kernel/linux
 
 git fetch --all --tags
-if [ "mariner" = "$OS_ID" ]; then
+if [ "azurelinux" = "" ]; then
   git branch -D rolling-lts/mariner || :
   git checkout -b rolling-lts/mariner -t origin/rolling-lts/mariner-3/6.6.96.1 || :
 else


### PR DESCRIPTION
## Summary
Replace the CBL-Mariner build target with Azure Linux 3.0.

## Changes
- Rename the build target from cbl-mariner to azurelinux
- Switch the base image to mcr.microsoft.com/azurelinux/base/core:3.0
- Use tdnf for package installation
- Keep using Microsoft's CBL-Mariner-Linux-Kernel repository for Azure Linux kernel builds
- Update entrypoint.sh to detect ID=azurelinux

## Test
- docker compose build azurelinux
- docker compose run --rm --env CI=true azurelinux